### PR TITLE
[WIP] cluster mode

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -1,0 +1,69 @@
+package kuiperbelt
+
+// Resolver is getting session from key.
+type Resolver interface {
+	Add(Session)
+	Get(string) (Session, error)
+	Delete(string) error
+	List() []Session
+}
+
+// MultiResolver is aggregation of Resolvers.
+type MultiResolver []Resolver
+
+// NewMultiResolver is constructor of MultiResolver.
+func NewMultiResolver(rs ...Resolver) MultiResolver {
+	return MultiResolver(rs)
+}
+
+// Add is adding a Session to primary Resolver.
+func (mr MultiResolver) Add(s Session) {
+	primary := mr.primary()
+	primary.Add(s)
+}
+
+func (mr MultiResolver) primary() Resolver {
+	return mr[0]
+}
+
+// Get is searching a Session by key from Resolvers.
+func (mr MultiResolver) Get(key string) (Session, error) {
+	for _, r := range mr {
+		s, err := r.Get(key)
+		if err == nil {
+			return s, nil
+		}
+
+		if err != errSessionNotFound {
+			return nil, err
+		}
+	}
+	return nil, errSessionNotFound
+}
+
+// Delete deletes a session in Resolvers.
+func (mr MultiResolver) Delete(key string) error {
+	for _, r := range mr {
+		err := r.Delete(key)
+		if err != nil {
+			return nil
+		}
+
+		if err != errSessionNotFound {
+			return err
+		}
+	}
+
+	return errSessionNotFound
+}
+
+// List return a slice of all sessions in Resolvers.
+func (mr MultiResolver) List() []Session {
+	ss := make([]Session, 0)
+	for _, r := range mr {
+		l := r.List()
+		ss = append(ss, l...)
+	}
+
+	return ss
+}

--- a/session.go
+++ b/session.go
@@ -57,7 +57,7 @@ func (p *SessionPool) Delete(key string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.m == nil {
-		return nil
+		return errSessionNotFound
 	}
 	if _, ok := p.m[key]; !ok {
 		return errSessionNotFound

--- a/session.go
+++ b/session.go
@@ -59,6 +59,9 @@ func (p *SessionPool) Delete(key string) error {
 	if p.m == nil {
 		return nil
 	}
+	if _, ok := p.m[key]; !ok {
+		return errSessionNotFound
+	}
 	delete(p.m, key)
 	return nil
 }

--- a/session_go19.go
+++ b/session_go19.go
@@ -46,6 +46,10 @@ func (p *SessionPool) Get(key string) (Session, error) {
 
 // Delete deletes a session.
 func (p *SessionPool) Delete(key string) error {
+	// XXX: This checker is weak for race.
+	if _, ok := p.m.Load(key); !ok {
+		return errSessionNotFound
+	}
 	p.m.Delete(key)
 	return nil
 }

--- a/session_test.go
+++ b/session_test.go
@@ -1,5 +1,9 @@
 package kuiperbelt
 
+import (
+	"testing"
+)
+
 type TestSession struct {
 	send chan Message
 	key  string
@@ -19,4 +23,12 @@ func (s *TestSession) Close() error {
 
 func (s *TestSession) Closed() <-chan struct{} {
 	return nil
+}
+
+func TestSessionPool__DeleteUnknownKey(t *testing.T) {
+	sp := &SessionPool{}
+	err := sp.Delete("unknown_key")
+	if err != errSessionNotFound {
+		t.Error("return not errSessionNotFound error when Delete unknown key.")
+	}
 }


### PR DESCRIPTION
## Motivation
In the case of running on container(ex. Docker), container is different having valid IP address and hostname. When resolving a WebSocket connection by a client based approach(ex. using a Redis, memcached...) that required valid IP address or hostname.

## What is use case of the cluster mode?
It is a client based resolver of the message to connection until now that the solution of HA and scale out.
The cluster mode is a resolver in server side. Now calling "server" is the kuiperbelt.

(無茶苦茶な英語疲れたのであとは日本語で書くと)
今まではフロントエンド(WebSocketで接続するクライアント側)に向けてロードバランサーを配置し、その配下にkuiperbeltを置く形を取っていたが、サーバサイドプッシュを送るバックエンド側からのリクエストはIPアドレスもしくは内部のDNSでの解決に頼っていました。つまりバックエンド側でのコネクション解決が必要となります。
cluster modeではkuiperbelt側でkuiperbelt間のネットワークを構成しコネクション解決を行います。つまり、実際のユースケースではロードバランサーを新たにバックエンド側との境界にも挟むことになります。これによりバックエンド側はどのkuiperbeltに目的のコネクションがつながっているかを意識せずにメッセージを送信することが出来るようになります。

## 解決方法

### Resolver interface

まずはじめにResolver interfaceを導入します。
Resolver interfaceはこれまで`SessionPool`と呼ばれる`Session`の集合であったもののを抽象化したものです。`SessionPool`の実体は`sync.Map`(go1.9でビルドした場合)ですが、この型は`key`からSessionを解決し、返す機能を持っています。
新たにResolver interfaceを導入し、`SessionPool`と置き換えることで、`sync.Map`以外の実装を導入することが出来ます。具体的に言うと、他のkuiperbeltに接続し、その`SessionPool`から`Session`を取ってくるものです。

### MultiResolver

MultiResolverはResolverの集合体です。これは自分の持つ`SessionPool`と他の解決方法を用いる`Resolver`を優先度付きで透過的に扱うための型です。

### 他のkuiperbeltが持っているsessionの解決方法[STAB]

- https://github.com/hashicorp/memberlist 他のkuiperbeltのリストを保持するために使用する
  - consulを外部に立ててconsulのAPIを叩くのと比較してどれ位のメリットが有るか
  - クラスタに入るためには最初にクラスタに加入しているkuiperbeltが立っているインスタンスのIPアドレスを知る必要がある
    - consul使えばservice登録されているのをconsulで名前解決すれば取ってくれるが、そもそもconsul自体同じ仕組みを使っているので鶏卵問題になる　そもそもコンテナ内にconsul立てない
    - AWS ECS, kubernates, docker swarm-modeなどはこの手のクラスタリング機構にまつわる問題について解決方法ある気がするので調べたほうが良さそう
- 実際のメッセージ送信にはmemberlistを使うのでいけるのか？
  - 新しい`Session`が出来た時に他のkuiperbeltに自分が持っている`SessionPool`にこれが追加されましたよと伝えるとか
  - つまりそれってレプリケーションですが、新しいノードが加入する時にちょっと遅延しそうではある
  - であれば都度解決する、キャッシュを行う方法となるけれどまあそれでいいかを検討する必要がありそう