### PR TITLE
Upstream messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ callback:
   connect: "http://localhost:12346/connect"
   # A close callback is similar working to the connect callback. A kuiperbelt send request this callback when closed connection by a client or timeout of idle(if set `idle_timeout`).
   close: "http:/localhost:12346/close"
+  # If set this and push message from client, POST to this url with-in message.
+  receive: "http:/localhost:12346/receive"
   timeout: 10s    # timeout of callback response
 # A log level of access log is `info`. But suppress this when this option is true.
 suppress_access_log: false 

--- a/_example/config_by_env.yml
+++ b/_example/config_by_env.yml
@@ -2,6 +2,7 @@ port: {{ env "EKBO_PORT" "9180" }}
 callback:
   connect: {{ env "EKBO_CONNECT_CALLBACK_URL" "http://localhost:12346/connect" }}
   close: {{ env "EKBO_CLOSE_CALLBACK_URL" "" }}
+  receive: {{ env "EKBO_RECEIVE_CALLBACK_URL" "" }}
   timeout: {{ env "EKBO_CALLBACK_TIMEOUT" "0" }}
 suppress_access_log: {{ env "EKBO_SUPPRESS_ACCESS_LOG" "false" }}
 session_header: {{ env "EKBO_SESSION_HEADER_NAME" "X-Kuiperbelt-Session" }}

--- a/config.go
+++ b/config.go
@@ -43,6 +43,7 @@ type Callback struct {
 	Connect string        `yaml:"connect"`
 	Close   string        `yaml:"close"`
 	Timeout time.Duration `yaml:"timeout"`
+	Receive string        `yaml:"receive"`
 }
 
 func NewConfig(filename string) (*Config, error) {

--- a/receiver.go
+++ b/receiver.go
@@ -1,0 +1,71 @@
+package kuiperbelt
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
+)
+
+type receivedMessage struct {
+	Message     io.Reader
+	ContentType string
+}
+
+func newReceivedMessage(msgType int, r io.Reader) receivedMessage {
+	var contentType string
+	switch msgType {
+	case websocket.TextMessage:
+		contentType = "text/plain"
+	case websocket.BinaryMessage:
+		contentType = "application/octet-stream"
+	}
+	return receivedMessage{
+		Message:     r,
+		ContentType: contentType,
+	}
+}
+
+// Receiver is proxy message from a client
+type Receiver interface {
+	Receive(context.Context, receivedMessage) error
+}
+
+// NewReceiverCallback is generate Receiver that proxy message to callback.Receive
+func newReceiverCallback(client *http.Client, callback *url.URL) Receiver {
+	return &receiverCallback{
+		client:   client,
+		callback: callback,
+	}
+}
+
+type receiverCallback struct {
+	client   *http.Client
+	callback *url.URL
+}
+
+func (r *receiverCallback) Receive(ctx context.Context, m receivedMessage) error {
+	req, err := http.NewRequest(
+		http.MethodPost,
+		r.callback.String(),
+		m.Message,
+	)
+	if err != nil {
+		return errors.Wrap(err, "cannot create receive callback request")
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", m.ContentType)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed post receive callback request")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("unsuccess post receive callback request")
+	}
+
+	return nil
+}

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -1,0 +1,124 @@
+package kuiperbelt
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
+)
+
+func TestDiscardReceiver(t *testing.T) {
+	receiver := newDiscardReceiver()
+
+	m := strings.NewReader("hello upstream callback")
+	msg := newReceivedMessage(
+		websocket.TextMessage,
+		http.Header{
+			"X-Kuiperbelt-Session": {"session_uuid"},
+		},
+		m,
+	)
+	ctx := context.Background()
+	err := receiver.Receive(ctx, msg)
+	if err != nil {
+		t.Errorf("unexpected error from Receive(): %s", err)
+	}
+}
+
+func TestCallbackReceiver__Success(t *testing.T) {
+	okBuf := &bytes.Buffer{}
+	okServer := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := io.Copy(okBuf, r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Errorf("unexpected error at okHandler: %s", err)
+				return
+			}
+			if r.Header.Get("X-Kuiperbelt-Session") != "session_uuid" {
+				w.WriteHeader(http.StatusUnauthorized)
+				t.Error("session key is not included at okHandler")
+				return
+
+			}
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	u, err := url.Parse(okServer.URL)
+	if err != nil {
+		t.Fatalf("unexpected error at Parse okServer.URL: %s", err)
+	}
+	receiver := newCallbackReceiver(http.DefaultClient, u)
+
+	m := strings.NewReader("hello upstream callback")
+	msg := newReceivedMessage(
+		websocket.TextMessage,
+		http.Header{
+			"X-Kuiperbelt-Session": {"session_uuid"},
+		},
+		m,
+	)
+	ctx := context.Background()
+	err = receiver.Receive(ctx, msg)
+	if err != nil {
+		t.Errorf("unexpected error from Receive(): %s", err)
+	}
+
+	if okBuf.String() != "hello upstream callback" {
+		t.Errorf("calling back message is not match: %s", okBuf.String())
+	}
+}
+
+func TestCallbackReceiver__Unauthorized(t *testing.T) {
+	ngBuf := &bytes.Buffer{}
+	ngServer := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := io.Copy(ngBuf, r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Errorf("unexpected error at ngHandler: %s", err)
+				return
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+		}),
+	)
+
+	u, err := url.Parse(ngServer.URL)
+	if err != nil {
+		t.Fatalf("unexpected error at Parse ngServer.URL: %s", err)
+	}
+	receiver := newCallbackReceiver(http.DefaultClient, u)
+
+	m := strings.NewReader("hello upstream callback")
+	msg := newReceivedMessage(
+		websocket.TextMessage,
+		http.Header{
+			"X-Kuiperbelt-Session": {"session_uuid"},
+		},
+		m,
+	)
+	ctx := context.Background()
+	err = receiver.Receive(ctx, msg)
+	if err == nil {
+		t.Errorf("Receive() success")
+	}
+	cerr, ok := errors.Cause(err).(errCallbackResponseNotOK)
+	if !ok {
+		t.Errorf("callback error is not errCallbackResponseNotOk: %+v", err)
+	}
+	if cerr != http.StatusUnauthorized {
+		t.Errorf("callback error is not StatusUnauthorized: %+v", cerr)
+	}
+
+	if ngBuf.String() != "hello upstream callback" {
+		t.Errorf("calling back message is not match: %s", ngBuf.String())
+	}
+}

--- a/server.go
+++ b/server.go
@@ -460,6 +460,11 @@ func (s *WebSocketSession) recvMessages() {
 			return
 		}
 		ctx := context.Background()
+		if timeout := s.server.Config.Callback.Timeout; timeout != 0 {
+			var cancel func()
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
 		h := http.Header{
 			s.server.Config.SessionHeader: {s.Key()},
 		}


### PR DESCRIPTION
### Motivation

- The kuiperbelt is only supported only downstream that messaging to client from server(a.k.a server-side push) until now.
  - I had thought can be substitute the upstream feature to RESTful API.
- However this design is unkind of client side development.

### What's this?

- This pull request implement the upstream messaging.
- Introduce `callback.Receive` on config
- POST to URL written in`callback.Receive` per WS Message.