### PR TITLE
add feature: changeable endpoint path by config or environment variable

### DIFF
--- a/_example/config_by_env.yml
+++ b/_example/config_by_env.yml
@@ -1,4 +1,10 @@
 port: {{ env "EKBO_PORT" "9180" }}
+path:
+  connect: {{ env "EKBO_CONNECT_PATH" "/connect" }}
+  close: {{ env "EKBO_CLOSE_PATH" "/close" }}
+  stats: {{ env "EKBO_STATS_PATH" "/stats" }}
+  send: {{ env "EKBO_SEND_PATH" "/send" }}
+  ping: {{ env "EKBO_PING_PATH" "/ping" }}
 callback:
   connect: {{ env "EKBO_CONNECT_CALLBACK_URL" "http://localhost:12346/connect" }}
   close: {{ env "EKBO_CLOSE_CALLBACK_URL" "" }}

--- a/config.go
+++ b/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	OriginPolicy      string            `yaml:"origin_policy"`
 	IdleTimeout       time.Duration     `yaml:"idle_timeout"`
 	SuppressAccessLog bool              `yaml:"suppress_access_log"`
+	Path              Path              `yaml:"path"`
 }
 
 type Callback struct {
@@ -44,6 +45,14 @@ type Callback struct {
 	Close   string        `yaml:"close"`
 	Timeout time.Duration `yaml:"timeout"`
 	Receive string        `yaml:"receive"`
+}
+
+type Path struct {
+	Connect string `yaml:"connect"`
+	Close   string `yaml:"close"`
+	Stats   string `yaml:"stats"`
+	Send    string `yaml:"send"`
+	Ping    string `yaml:"ping"`
 }
 
 func NewConfig(filename string) (*Config, error) {
@@ -94,6 +103,22 @@ func tryBindDefaultToConfig(c *Config) (*Config, error) {
 			strings.Join(validOriginPolicies, ", "),
 			c.OriginPolicy,
 		)
+	}
+
+	if c.Path.Connect == "" {
+		c.Path.Connect = "/connect"
+	}
+	if c.Path.Close == "" {
+		c.Path.Close = "/close"
+	}
+	if c.Path.Stats == "" {
+		c.Path.Stats = "/stats"
+	}
+	if c.Path.Send == "" {
+		c.Path.Send = "/send"
+	}
+	if c.Path.Ping == "" {
+		c.Path.Ping = "/ping"
 	}
 
 	return c, nil

--- a/config_test.go
+++ b/config_test.go
@@ -37,6 +37,13 @@ var TestConfig = Config{
 	},
 	Endpoint:     "localhost",
 	OriginPolicy: DefaultOriginPolicy,
+	Path: Path{
+		Connect: "/connect",
+		Close:   "/close",
+		Stats:   "/stats",
+		Ping:    "/ping",
+		Send:    "/send",
+	},
 }
 
 func TestConfig__NewConfig(t *testing.T) {

--- a/proxy.go
+++ b/proxy.go
@@ -42,9 +42,9 @@ func NewProxy(c Config, s *Stats, p *SessionPool) *Proxy {
 
 func (p *Proxy) Register() {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/send", p.SendHandlerFunc)
-	mux.HandleFunc("/close", p.CloseHandlerFunc)
-	mux.HandleFunc("/ping", p.PingHandlerFunc)
+	mux.HandleFunc(p.Config.Path.Send, p.SendHandlerFunc)
+	mux.HandleFunc(p.Config.Path.Close, p.CloseHandlerFunc)
+	mux.HandleFunc(p.Config.Path.Ping, p.PingHandlerFunc)
 	if p.Config.SuppressAccessLog {
 		http.Handle("/", mux)
 	} else {

--- a/server.go
+++ b/server.go
@@ -139,8 +139,8 @@ func (s *WebSocketServer) Register() {
 		MaxIdleConnsPerHost: CALLBACK_CLIENT_MAX_CONNS_PER_HOST,
 		IdleConnTimeout:     callbackPersistentLimit,
 	}
-	http.HandleFunc("/connect", s.Handler)
-	http.HandleFunc("/stats", s.StatsHandler)
+	http.HandleFunc(s.Config.Path.Connect, s.Handler)
+	http.HandleFunc(s.Config.Path.Stats, s.StatsHandler)
 }
 
 func (s *WebSocketServer) StatsHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
I working to support Socket.IO with sidecar daemon now. However, A connecting path of using Socket.IO(Engine.IO) is require slash in postfix.

So this pull request is fix that to changeable paths of listening the WebSocket.