### PR TITLE
Process Close request even if it contains a non-existent session ID.

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -177,11 +177,12 @@ func (p *Proxy) CloseHandlerFunc(w http.ResponseWriter, r *http.Request) {
 
 	ss, err := p.handlerPreHook(w, r)
 	se, ok := err.(sessionErrors)
-	if ok && p.Config.StrictBroadcast {
-		p.sessionKeysErrorHandler(w, se, ss)
-		return
-	}
-	if err != nil {
+	if ok {
+		if p.Config.StrictBroadcast {
+			p.sessionKeysErrorHandler(w, se, ss)
+			return
+		}
+	} else if err != nil {
 		return
 	}
 


### PR DESCRIPTION
Thanks for the great software.

If a `POST /close` request from a backend application contains one or more non-existent Session IDs, the close will not be processed even if StrictBroadcast is False (default).

And also In that case, the Backend application will receive a response with `Response status code: 200, Response body: empty`.

It seems that the expected behavior should be the same as `POST /send`.

- Even if a Session ID that does not exist is included, Close processing will be performed for the Session ID that does exist.
- If a non-existent Session ID is included, return a Response body in json format.
    - i.e., `{"errors":[{"error": "session is not found.", "session": "bob"}], "result": "OK"}`