### PR TITLE
Fix close callback

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -195,9 +195,10 @@ func (p *Proxy) CloseHandlerFunc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	message := Message{
-		Body:        buf,
-		ContentType: r.Header.Get("Content-Type"),
-		LastWord:    true,
+		Body:          buf,
+		ContentType:   r.Header.Get("Content-Type"),
+		LastWord:      true,
+		FromPostClose: true,
 	}
 
 	var ctx context.Context

--- a/server_test.go
+++ b/server_test.go
@@ -36,7 +36,7 @@ func (s *testSuccessConnectCallbackServer) IsCallbacked() bool {
 func (s *testSuccessConnectCallbackServer) IsClosed() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.isCallbacked
+	return s.isClosed
 }
 
 func (s *testSuccessConnectCallbackServer) Header() http.Header {

--- a/session.go
+++ b/session.go
@@ -17,10 +17,11 @@ type SessionPool struct {
 
 // Message is a message container for communicating through sessions.
 type Message struct {
-	Body        []byte
-	ContentType string
-	Session     string
-	LastWord    bool
+	Body          []byte
+	ContentType   string
+	Session       string
+	LastWord      bool
+	FromPostClose bool
 }
 
 // Session is an interface for sessions.

--- a/session_go19.go
+++ b/session_go19.go
@@ -16,10 +16,11 @@ type SessionPool struct {
 
 // Message is a message container for communicating through sessions.
 type Message struct {
-	Body        []byte
-	ContentType string
-	Session     string
-	LastWord    bool
+	Body          []byte
+	ContentType   string
+	Session       string
+	LastWord      bool
+	FromPostClose bool
 }
 
 // Session is an interface for sessions.


### PR DESCRIPTION
Fixes #65 

Do not fire Close callback in the case of `POST /close`.